### PR TITLE
Email DAG Upload + Scoring Changes

### DIFF
--- a/dags/email_campaigns_dag.py
+++ b/dags/email_campaigns_dag.py
@@ -1,0 +1,253 @@
+import logging
+from datetime import datetime
+from datetime import timedelta
+from airflow import DAG
+from airflow.contrib.operators.snowflake_operator import SnowflakeOperator
+from airflow.providers.amazon.aws.operators.sns import SnsPublishOperator
+from airflow.operators.python_operator import PythonOperator
+from airflow.contrib.hooks.snowflake_hook import SnowflakeHook
+logging.basicConfig(level=logging.ERROR)
+logger = logging.getLogger(__name__)
+
+# ---Variable definition--- #
+SNS_ARN = 'arn:aws:sns:us-east-2:698085094823:Intent_Scoring'
+DAG_NAME = 'Email_Campaigns'
+TRANSFORM_CONNECTION = "Airflow-Dev_Transform-connection"
+
+dt = datetime.now()
+date_time = dt.strftime("%m%d%Y%H:%M:%S")
+DOW = dt.weekday()
+
+# --- Function Definitions --- #
+def end_success():
+  logger.info("DAG Ended Successfully.")
+
+def on_failure_callback(context):
+    op = SnsPublishOperator(
+        task_id="dag_failure"
+        ,target_arn=SNS_ARN
+        ,subject="DAG FAILED: "+DAG_NAME
+        ,message=f"Task has failed, task_instance_key_str: {context['task_instance_key_str']}"
+    )
+    op.execute(context)
+
+    
+def on_success_callback(context):
+    op = SnsPublishOperator(
+        task_id="dag_success"
+        ,target_arn=SNS_ARN
+        ,subject="DAG Success"
+        ,message=f"{DAG_NAME} has succeeded, run_id: {context['run_id']}"
+    )
+    op.execute(context)
+    
+TRANSFORM_CONN = "Airflow-Dev_Transform-connection"
+
+dag = DAG(DAG_NAME, start_date = datetime(2022, 12, 7), schedule_interval = '@daily', catchup=False, on_failure_callback=on_failure_callback, on_success_callback=None,
+        default_args={'depends_on_past' : False,'retries' : 0,'on_failure_callback': on_failure_callback,'on_success_callback': None})
+
+#---- SNOWFLAKE QUERIES ----#
+company_clicks_query = ["""
+create or replace table dev_email_campaigns.activity.company_clicks as
+select
+    cam_id,
+    dev_datamart.public.domain_normalizer(domain) as normalized_company_domain,
+    date(time) as date,
+    split_part(link,'?email',1) as page_url, --index is 1-based
+    count(*) as frequency
+from  DEV_EMAIL_CAMPAIGNS.RAW_DATA.CLICKS
+where cam_id is not null
+and normalized_company_domain is not null
+and date is not null
+and page_url is not null
+group by 1,2,3,4;
+"""]
+
+company_opens_query = ["""
+create or replace table dev_email_campaigns.activity.company_opens as
+select
+    cam_id,
+    dev_datamart.public.domain_normalizer(domain) as normalized_company_domain,
+    date(time) as date,
+    count(*) as frequency
+from  DEV_EMAIL_CAMPAIGNS.RAW_DATA.OPENS
+where cam_id is not null
+and normalized_company_domain is not null
+and date is not null
+group by 1,2,3;
+"""]
+
+unique_urls_query = ["""
+create or replace table dev_email_campaigns.content.unique_urls as
+select 
+       split_part(link,'?email',1) as page_url, --index is 1-based
+       any_value(hash(page_url)) as page_url_hash,
+       any_value(dev_datamart.public.domain_normalizer(split_part(replace(replace(page_url, 'http://'), 'https://'),'/',1))) as publisher_domain_normalized,
+       min(date(time)) as first_seen,
+       max(date(time)) as last_seen,
+       count(*) as frequency
+from "DEV_EMAIL_CAMPAIGNS"."RAW_DATA"."CLICKS"
+group by 1;
+"""]
+
+campaign_content_query = ["""
+create or replace table dev_email_campaigns.content.campaign_content as
+select distinct
+    cam_id,
+    split_part(link,'?email',1) as page_url --index is 1-based
+from "DEV_EMAIL_CAMPAIGNS"."RAW_DATA"."CLICKS";
+"""]
+
+campaign_topics_query = ["""
+create or replace table dev_email_campaigns.content.campaign_topics as
+with joined_topics as (
+select
+    t.cam_id,
+    f.value:parentCategory::varchar as parent_category,
+    f.value:category::varchar as category,
+    f.value:topic::varchar as topic,
+    sum(f.value:probability::number(5,4)) as summed_topic_probabilities
+from (select a.cam_id, a.page_url, b.intent_topics from "DEV_EMAIL_CAMPAIGNS"."CONTENT"."CAMPAIGN_CONTENT" a
+join "DEV_AIML"."TAXONOMY_CLASSIFIER"."OUTPUT" b
+on a.page_url = b.page_url) t,
+lateral flatten(input => t.intent_topics) f
+group by 1,2,3,4
+),
+campaign_totals as (
+select
+    cam_id,
+    sum(summed_topic_probabilities) as total
+from joined_topics
+group by 1)
+select
+    a.cam_id,
+    parent_category,
+    category,
+    topic,
+    summed_topic_probabilities/total as proportion
+from joined_topics a
+join campaign_totals b
+on a.cam_id = b.cam_id;
+"""]
+
+web_scraper_input_query = ["""
+merge into "DEV_AIML"."WEB_SCRAPER"."INPUT_CACHE" t
+using (
+    select distinct a.page_url
+    from "DEV_EMAIL_CAMPAIGNS"."CONTENT"."UNIQUE_URLS" a
+    left join "DEV_AIML"."WEB_SCRAPER"."RESULTS" b
+    on a.page_url = b.page_url
+    where last_scraped is null) s
+on t.page_url = s.page_url
+when not matched then insert
+(page_url, date_inserted)
+values (s.page_url, current_date)
+when matched then update set
+date_inserted = current_date;
+"""]
+
+prescoring_query = ["""
+create or replace table dev_email_campaigns.activity.prescoring as
+with joined_clicks as (
+select
+    t.normalized_company_domain,
+    t.date,
+    f.value:parentCategory::varchar as parent_category,
+    f.value:category::varchar as category,
+    f.value:topic::varchar as topic,
+    sum(t.frequency * f.value:probability::number(5,4)) as weighted_clicks
+from (select a.normalized_company_domain, a.date, a.frequency, b.intent_topics 
+      from "DEV_EMAIL_CAMPAIGNS"."ACTIVITY"."COMPANY_CLICKS" a
+     join "DEV_AIML"."TAXONOMY_CLASSIFIER"."OUTPUT" b
+     on a.page_url = b.page_url) t,
+lateral flatten(input => t.intent_topics) f
+group by 1,2,3,4,5),
+
+joined_opens as (
+select
+    a.normalized_company_domain,
+    a.date,
+    b.parent_category,
+    b.category,
+    b.topic,
+    sum(a.frequency * b.proportion) as weighted_opens
+from "DEV_EMAIL_CAMPAIGNS"."ACTIVITY"."COMPANY_OPENS" a
+join "DEV_EMAIL_CAMPAIGNS"."CONTENT"."CAMPAIGN_TOPICS" b
+on a.cam_id = b.cam_id
+group by 1,2,3,4,5)
+
+select
+    coalesce(c.normalized_company_domain, o.normalized_company_domain) as normalized_company_domain,
+    coalesce(c.date, o.date) as date,
+    coalesce(c.parent_category, o.parent_category) as parent_category,
+    coalesce(c.category, o.category) as category,
+    coalesce(c.topic, o.topic) as topic,
+    ifnull(weighted_opens, 0) as weighted_opens,
+    ifnull(weighted_clicks, 0) as weighted_clicks
+from joined_clicks c
+full outer join joined_opens o
+on c.normalized_company_domain = o.normalized_company_domain
+and c.date = o.date
+and c.parent_category = o.parent_category
+and c.category = o.category
+and c.topic = o.topic;
+"""]
+
+with dag:
+    # --- activity steps --- #
+    company_clicks_exec = SnowflakeOperator(
+    task_id= "company_clicks",
+    sql=company_clicks_query,
+    snowflake_conn_id= TRANSFORM_CONNECTION,
+    )
+
+    company_opens_exec = SnowflakeOperator(
+    task_id= "company_opens",
+    sql=company_opens_query,
+    snowflake_conn_id= TRANSFORM_CONNECTION,
+    )
+
+    #--- content steps ---- #
+    unique_urls_exec = SnowflakeOperator(
+    task_id= "unique_urls",
+    sql=unique_urls_query,
+    snowflake_conn_id= TRANSFORM_CONNECTION,
+    )
+
+    campaign_content_exec = SnowflakeOperator(
+    task_id= "campaign_content",
+    sql=campaign_content_query,
+    snowflake_conn_id= TRANSFORM_CONNECTION,
+    )
+
+    campaign_topics_exec = SnowflakeOperator(
+    task_id= "campaign_topics",
+    sql=campaign_topics_query,
+    snowflake_conn_id= TRANSFORM_CONNECTION,
+    )
+
+    web_scraper_input_exec = SnowflakeOperator(
+    task_id= "web_scraper_input",
+    sql=web_scraper_input_query,
+    snowflake_conn_id= TRANSFORM_CONNECTION,
+    )
+
+    #---- prescoring step ---- #
+    prescoring_exec = SnowflakeOperator(
+    task_id= "prescoring",
+    sql=prescoring_query,
+    snowflake_conn_id= TRANSFORM_CONNECTION,
+    )
+
+    # --- End Success --- #
+    end_success_exec = PythonOperator(
+    task_id= "end_success",
+    python_callable = end_success,
+    on_success_callback = on_success_callback
+    )
+
+    #--- DAG FLOW ----#
+    [company_clicks_exec, company_opens_exec, campaign_topics_exec] >> prescoring_exec
+    campaign_content_exec >> campaign_topics_exec
+    unique_urls_exec >> web_scraper_input_exec
+    [prescoring_exec, web_scraper_input_exec] >> end_success_exec


### PR DESCRIPTION
- first upload of email signals dag
- scoring now includes all data sources (email clicks + opens, leadsift, pixel, bidstream)