### PR TITLE
IP Logic Update: Datamart

### DIFF
--- a/dags/ip_flow_dag.py
+++ b/dags/ip_flow_dag.py
@@ -235,33 +235,48 @@ WHEN NOT MATCHED THEN
 
 snowflake_create_devmart_domain_query = [
     f"""create or replace table {DATAMART_DATABASE}.ENTITY_MAPPINGS.IP_TO_COMPANY_DOMAIN as
-with most_recent as(
+with scores as(
     select distinct
     ip,
-    first_value(normalized_company_domain) over (partition by ip, source order by date desc) as latest_domain,
+    normalized_company_domain,
     source,
-    source_confidence
-from {DATAMART_DATABASE}.ENTITY_MAPPINGS.IP_TO_COMPANY_DOMAIN_OBSERVATIONS
-),
-rolled_obs as (
-    select
-    ip,
-    latest_domain,
-    array_agg(distinct source) as sources,
-    iff(array_size(sources)>1, 1, sum((case source
+    source_confidence,
+    case source
         when 'DIGITAL ELEMENT' then 0.3
         when 'IP FLOW' then 0.5
         when 'FIVE BY FIVE' then 0.9
-    else 0.0 end)*ifnull(source_confidence, 1))) as score
-  from most_recent
-  group by 1,2
-) 
-
-select distinct
+        when 'LASTBOUNCE' then 0.7
+    else 0.5 end as source_score,
+    1.0-(0.01*(current_date - date)) as recency_score,
+    ifnull(source_confidence, 1)*recency_score*source_score as score
+from {DATAMART_DATABASE}.ENTITY_MAPPINGS.IP_TO_COMPANY_DOMAIN_OBSERVATIONS
+where normalized_company_domain != 'Shared'
+and normalized_company_domain is not null
+and len(normalized_company_domain)>1
+),
+map_scores as (
+    select
     ip,
-    first_value(latest_domain) over (partition by ip order by score desc) as normalized_company_domain,
-    first_value(score) over (partition by ip order by score desc) as score
-from rolled_obs;"""
+    normalized_company_domain,
+    array_agg(distinct source) as sources,
+    sum(score) as score
+  from scores
+  group by 1,2
+),
+score_totals as (
+    select
+    ip,
+    sum(score) as score_total
+    from map_scores
+  group by 1
+)
+select distinct
+    a.ip,
+    normalized_company_domain,
+    greatest(0.1,score/score_total) as score
+from map_scores a
+join score_totals b
+on a.ip = b.ip;"""
     ]
 
 snowflake_normalize_loc_staging_query = [


### PR DESCRIPTION
- Edited 5x5 DAG to leverage domains in new field, "domain array"
- Edited IP->Domain scoring table logic to be pairwise unique on IP-Domain, not unique on IP (this will increase coverage)
- Edited IP->Domain scoring logic to include recency as a factor and include Lastbounce IP mappings.